### PR TITLE
feat: サイドバーのカテゴリ一覧に記事数を表示

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -15,10 +15,10 @@ export const metadata: Metadata = {
  * Aboutページ。
  */
 export default async function AboutPage() {
-  const { categories, tagCounts } = await getBlogViewContext();
+  const { categoryCounts, tagCounts } = await getBlogViewContext();
 
   return (
-    <BlogLayout categories={categories} tagCounts={tagCounts}>
+    <BlogLayout categoryCounts={categoryCounts} tagCounts={tagCounts}>
       <div className="max-w-none">
         <header className="mb-10">
           <h1 className="text-3xl md:text-4xl font-bold text-text">About</h1>

--- a/app/blog/categories/[category]/page.tsx
+++ b/app/blog/categories/[category]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({
 export default async function CategoryPage({ params }: { params: Promise<{ category: string }> }) {
   const { category: slug } = await params;
 
-  const { allPosts: posts, categories, tagCounts } = await getBlogViewContext();
+  const { allPosts: posts, categories, categoryCounts, tagCounts } = await getBlogViewContext();
   const actualCategory = resolveSlugOrNotFound(slug, categories, categoryToSlug);
 
   const filteredPosts = posts.filter((p) => p.category === actualCategory);
@@ -49,7 +49,7 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
   return (
     <PostListPage
       tagCounts={tagCounts}
-      categories={categories}
+      categoryCounts={categoryCounts}
       posts={filteredPosts}
       heading={`Category: ${actualCategory}`}
       currentPage={1}

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -27,7 +27,7 @@ export default async function PageView({ params }: Props) {
     redirect('/');
   }
 
-  const { allPosts, categories, tagCounts } = await getBlogViewContext();
+  const { allPosts, categoryCounts, tagCounts } = await getBlogViewContext();
   const { posts, totalPages } = paginatePosts(
     allPosts,
     currentPage,
@@ -41,7 +41,7 @@ export default async function PageView({ params }: Props) {
   return (
     <PostListPage
       tagCounts={tagCounts}
-      categories={categories}
+      categoryCounts={categoryCounts}
       posts={posts}
       currentPage={currentPage}
       totalPages={totalPages}

--- a/app/blog/posts/[slug]/page.tsx
+++ b/app/blog/posts/[slug]/page.tsx
@@ -81,7 +81,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   const { slug } = await params;
   const post = await getPost(slug);
 
-  const { categories, tagCounts } = await getBlogViewContext();
+  const { categoryCounts, tagCounts } = await getBlogViewContext();
 
   if (!post) notFound();
 
@@ -114,7 +114,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   };
 
   return (
-    <BlogLayout tagCounts={tagCounts} toc={post.toc} categories={categories}>
+    <BlogLayout tagCounts={tagCounts} toc={post.toc} categoryCounts={categoryCounts}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/app/blog/tags/[tag]/page.tsx
+++ b/app/blog/tags/[tag]/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata({
 export default async function TagPage({ params }: { params: Promise<{ tag: string }> }) {
   const { tag: slug } = await params;
 
-  const { allPosts: posts, categories, tagCounts } = await getBlogViewContext();
+  const { allPosts: posts, categoryCounts, tagCounts } = await getBlogViewContext();
 
   // 全タグを取得
   const allTags = getAllTags(posts);
@@ -59,7 +59,7 @@ export default async function TagPage({ params }: { params: Promise<{ tag: strin
   return (
     <PostListPage
       tagCounts={tagCounts}
-      categories={categories}
+      categoryCounts={categoryCounts}
       posts={filteredPosts}
       heading={`Tag: #${actualTag}`}
       emptyMessage="このタグの記事はありません。"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,13 +20,13 @@ const POSTS_PER_PAGE = siteConfig.pagination.postsPerPage;
  * トップページ（最新記事一覧）。
  */
 export default async function Home() {
-  const { categories, tagCounts, allPosts } = await getBlogViewContext();
+  const { categoryCounts, tagCounts, allPosts } = await getBlogViewContext();
   const { posts, totalPages } = paginatePosts(allPosts, 1, POSTS_PER_PAGE);
 
   return (
     <PostListPage
       tagCounts={tagCounts}
-      categories={categories}
+      categoryCounts={categoryCounts}
       posts={posts}
       currentPage={1}
       totalPages={totalPages}

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -14,10 +14,10 @@ export const metadata: Metadata = {
  * プライバシーポリシーページ。
  */
 export default async function PrivacyPolicyPage() {
-  const { categories, tagCounts } = await getBlogViewContext();
+  const { categoryCounts, tagCounts } = await getBlogViewContext();
 
   return (
-    <BlogLayout categories={categories} tagCounts={tagCounts}>
+    <BlogLayout categoryCounts={categoryCounts} tagCounts={tagCounts}>
       <div className="max-w-none">
         <header className="mb-10">
           <h1 className="text-3xl md:text-4xl font-bold text-text">

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -17,11 +17,11 @@ export const metadata: Metadata = {
  * サイトマップページ。
  */
 export default async function SitemapPage() {
-  const { allPosts: posts, categories, tagCounts } = await getBlogViewContext();
+  const { allPosts: posts, categories, categoryCounts, tagCounts } = await getBlogViewContext();
   const tags = tagCounts.map((tc) => tc.tag);
 
   return (
-    <BlogLayout categories={categories} tagCounts={tagCounts}>
+    <BlogLayout categoryCounts={categoryCounts} tagCounts={tagCounts}>
       <div className="max-w-none">
         <header className="mb-10">
           <h1 className="text-3xl md:text-4xl font-bold text-text">サイトマップ</h1>

--- a/src/components/BlogLayout.tsx
+++ b/src/components/BlogLayout.tsx
@@ -1,6 +1,6 @@
 // src/components/BlogLayout.tsx
 import Sidebar from '@/src/components/Sidebar';
-import type { CategoryCount, TagCount } from '@/src/lib/posts-view';
+import type { CategoryCount, TagCount } from '@/src/lib/post-taxonomy';
 import { TocItem } from '@/src/types/post';
 import { ReactNode } from 'react';
 

--- a/src/components/BlogLayout.tsx
+++ b/src/components/BlogLayout.tsx
@@ -1,6 +1,6 @@
 // src/components/BlogLayout.tsx
 import Sidebar from '@/src/components/Sidebar';
-import type { TagCount } from '@/src/lib/posts-view';
+import type { CategoryCount, TagCount } from '@/src/lib/posts-view';
 import { TocItem } from '@/src/types/post';
 import { ReactNode } from 'react';
 
@@ -10,14 +10,14 @@ import { ReactNode } from 'react';
 interface BlogLayoutProps {
   children: ReactNode;
   toc?: TocItem[];
-  categories?: string[];
+  categoryCounts?: CategoryCount[];
   tagCounts?: TagCount[];
 }
 
 /**
  * ブログページの共通レイアウト。
  */
-export default function BlogLayout({ children, toc, categories, tagCounts }: BlogLayoutProps) {
+export default function BlogLayout({ children, toc, categoryCounts, tagCounts }: BlogLayoutProps) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-4">
       <div className="grid gap-8 md:grid-cols-[2fr_1fr]">
@@ -26,7 +26,7 @@ export default function BlogLayout({ children, toc, categories, tagCounts }: Blo
 
         {/* サイドバー */}
         <aside className="relative">
-          <Sidebar toc={toc} categories={categories} tagCounts={tagCounts} />
+          <Sidebar toc={toc} categoryCounts={categoryCounts} tagCounts={tagCounts} />
         </aside>
       </div>
     </div>

--- a/src/components/PostListPage.tsx
+++ b/src/components/PostListPage.tsx
@@ -2,12 +2,12 @@
 import BlogLayout from '@/src/components/BlogLayout';
 import Pagination from '@/src/components/Pagination';
 import PostCardList from '@/src/components/PostCardList';
-import type { TagCount } from '@/src/lib/posts-view';
+import type { CategoryCount, TagCount } from '@/src/lib/posts-view';
 import type { PostMeta } from '@/src/types/post';
 
 type PostListPageProps = {
   tagCounts: TagCount[];
-  categories: string[];
+  categoryCounts: CategoryCount[];
   posts: PostMeta[];
   heading?: string;
   emptyMessage?: string;
@@ -20,7 +20,7 @@ type PostListPageProps = {
  */
 export default function PostListPage({
   tagCounts,
-  categories,
+  categoryCounts,
   posts,
   heading,
   emptyMessage,
@@ -28,7 +28,7 @@ export default function PostListPage({
   totalPages,
 }: PostListPageProps) {
   return (
-    <BlogLayout tagCounts={tagCounts} categories={categories}>
+    <BlogLayout tagCounts={tagCounts} categoryCounts={categoryCounts}>
       <div>
         {heading && <h1 className="text-3xl font-bold mb-6">{heading}</h1>}
 

--- a/src/components/PostListPage.tsx
+++ b/src/components/PostListPage.tsx
@@ -2,7 +2,7 @@
 import BlogLayout from '@/src/components/BlogLayout';
 import Pagination from '@/src/components/Pagination';
 import PostCardList from '@/src/components/PostCardList';
-import type { CategoryCount, TagCount } from '@/src/lib/posts-view';
+import type { CategoryCount, TagCount } from '@/src/lib/post-taxonomy';
 import type { PostMeta } from '@/src/types/post';
 
 type PostListPageProps = {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 // src/components/Sidebar.tsx
 'use client';
 import TagCloud from '@/src/components/TagCloud';
-import type { CategoryCount, TagCount } from '@/src/lib/posts-view';
+import type { CategoryCount, TagCount } from '@/src/lib/post-taxonomy';
 import { categoryToSlug } from '@/src/lib/utils';
 import type { TocItem } from '@/src/types/post';
 import { Menu } from 'lucide-react';

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 // src/components/Sidebar.tsx
 'use client';
 import TagCloud from '@/src/components/TagCloud';
-import type { TagCount } from '@/src/lib/posts-view';
+import type { CategoryCount, TagCount } from '@/src/lib/posts-view';
 import { categoryToSlug } from '@/src/lib/utils';
 import type { TocItem } from '@/src/types/post';
 import { Menu } from 'lucide-react';
@@ -21,14 +21,14 @@ const SearchBox = dynamic(() => import('@/src/components/SearchBox'), {
  */
 type SidebarProps = {
   toc?: TocItem[];
-  categories?: string[];
+  categoryCounts?: CategoryCount[];
   tagCounts?: TagCount[];
 };
 
 /**
  * 記事一覧・カテゴリ・目次を表示するサイドバー。
  */
-export default function Sidebar({ toc, categories, tagCounts }: SidebarProps) {
+export default function Sidebar({ toc, categoryCounts, tagCounts }: SidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const hasToc = !!(toc && toc.length > 0);
 
@@ -66,18 +66,19 @@ export default function Sidebar({ toc, categories, tagCounts }: SidebarProps) {
     <div className="space-y-6 h-full">
       <SearchBox />
 
-      {/* カテゴリ・タグ一覧（省略せずそのまま） */}
-      {categories && categories.length > 0 && (
+      {/* カテゴリ一覧 */}
+      {categoryCounts && categoryCounts.length > 0 && (
         <div className="p-5 border border-border/60 rounded-3xl bg-card/70 backdrop-blur-md shadow-sm">
           <h2 className="font-bold text-lg mb-4 text-text">カテゴリ</h2>
           <ul className="space-y-2 text-sm">
-            {categories.map((cat) => (
-              <li key={cat}>
+            {categoryCounts.map(({ category, count }) => (
+              <li key={category}>
                 <Link
-                  href={`/blog/categories/${categoryToSlug(cat)}`}
-                  className="text-text/80 hover:text-accent hover:underline block"
+                  href={`/blog/categories/${categoryToSlug(category)}`}
+                  className="flex justify-between items-center text-text/80 hover:text-accent hover:underline"
                 >
-                  {cat}
+                  <span>{category}</span>
+                  <span className="ml-2 text-xs text-text/50 tabular-nums">({count})</span>
                 </Link>
               </li>
             ))}

--- a/src/components/TagCloud.tsx
+++ b/src/components/TagCloud.tsx
@@ -1,7 +1,7 @@
 // src/components/TagCloud.tsx
 import { tagToSlug } from '@/src/lib/utils';
 import Link from 'next/link';
-import type { TagCount } from '@/src/lib/posts-view';
+import type { TagCount } from '@/src/lib/post-taxonomy';
 
 type Props = {
   tagCounts: TagCount[];

--- a/src/lib/post-taxonomy.ts
+++ b/src/lib/post-taxonomy.ts
@@ -9,6 +9,19 @@ export function getAllTags(posts: PostMeta[]): string[] {
 }
 
 /**
+ * 投稿配列からカテゴリと出現回数の一覧を返す（アルファベット順）。
+ */
+export function getCategoriesWithCount(posts: PostMeta[]): { category: string; count: number }[] {
+  const countMap = new Map<string, number>();
+  for (const post of posts) {
+    countMap.set(post.category, (countMap.get(post.category) ?? 0) + 1);
+  }
+  return Array.from(countMap.entries())
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+/**
  * 投稿配列からタグと出現回数の一覧を返す（出現回数の多い順）。
  */
 export function getTagsWithCount(posts: PostMeta[]): { tag: string; count: number }[] {

--- a/src/lib/post-taxonomy.ts
+++ b/src/lib/post-taxonomy.ts
@@ -1,6 +1,17 @@
 // src/lib/post-taxonomy.ts
 import type { PostMeta } from '@/src/types/post';
 
+export type CategoryCount = {
+  category: string;
+  count: number;
+};
+
+export type TagCount = {
+  tag: string;
+  count: number;
+};
+
+
 /**
  * 投稿配列から重複なしのタグ一覧を返す。
  */
@@ -11,7 +22,7 @@ export function getAllTags(posts: PostMeta[]): string[] {
 /**
  * 投稿配列からカテゴリと出現回数の一覧を返す（アルファベット順）。
  */
-export function getCategoriesWithCount(posts: PostMeta[]): { category: string; count: number }[] {
+export function getCategoriesWithCount(posts: PostMeta[]): CategoryCount[] {
   const countMap = new Map<string, number>();
   for (const post of posts) {
     countMap.set(post.category, (countMap.get(post.category) ?? 0) + 1);
@@ -24,7 +35,7 @@ export function getCategoriesWithCount(posts: PostMeta[]): { category: string; c
 /**
  * 投稿配列からタグと出現回数の一覧を返す（出現回数の多い順）。
  */
-export function getTagsWithCount(posts: PostMeta[]): { tag: string; count: number }[] {
+export function getTagsWithCount(posts: PostMeta[]): TagCount[] {
   const countMap = new Map<string, number>();
   for (const post of posts) {
     for (const tag of post.tags) {

--- a/src/lib/posts-view.ts
+++ b/src/lib/posts-view.ts
@@ -1,6 +1,11 @@
 // src/lib/posts-view.ts
 import { getAllPostMeta } from '@/src/lib/posts-server';
-import { getCategoriesWithCount, getTagsWithCount } from '@/src/lib/post-taxonomy';
+import {
+  getCategoriesWithCount,
+  getTagsWithCount,
+  type CategoryCount,
+  type TagCount,
+} from '@/src/lib/post-taxonomy';
 import type { PostMeta } from '@/src/types/post';
 
 type PaginatedPosts = {
@@ -8,15 +13,6 @@ type PaginatedPosts = {
   totalPages: number;
 };
 
-export type TagCount = {
-  tag: string;
-  count: number;
-};
-
-export type CategoryCount = {
-  category: string;
-  count: number;
-};
 
 type BlogViewContext = {
   allPosts: PostMeta[];

--- a/src/lib/posts-view.ts
+++ b/src/lib/posts-view.ts
@@ -1,6 +1,6 @@
 // src/lib/posts-view.ts
 import { getAllPostMeta } from '@/src/lib/posts-server';
-import { getTagsWithCount } from '@/src/lib/post-taxonomy';
+import { getCategoriesWithCount, getTagsWithCount } from '@/src/lib/post-taxonomy';
 import type { PostMeta } from '@/src/types/post';
 
 type PaginatedPosts = {
@@ -13,9 +13,15 @@ export type TagCount = {
   count: number;
 };
 
+export type CategoryCount = {
+  category: string;
+  count: number;
+};
+
 type BlogViewContext = {
   allPosts: PostMeta[];
   categories: string[];
+  categoryCounts: CategoryCount[];
   tagCounts: TagCount[];
 };
 
@@ -24,13 +30,14 @@ type BlogViewContext = {
  */
 export async function getBlogViewContext(): Promise<BlogViewContext> {
   const allPosts = await getAllPostMeta();
-  const categories = Array.from(new Set(allPosts.map((post) => post.category))).sort();
+  const categoryCounts = getCategoriesWithCount(allPosts);
+  const categories = categoryCounts.map((c) => c.category);
   const tagCounts = getTagsWithCount(allPosts);
 
   // クライアントに渡すデータから plaintext を除去して軽量化
   const lightPosts = allPosts.map(({ plaintext: _plaintext, ...rest }) => rest) as PostMeta[];
 
-  return { allPosts: lightPosts, categories, tagCounts };
+  return { allPosts: lightPosts, categories, categoryCounts, tagCounts };
 }
 
 /**


### PR DESCRIPTION
## Summary

- `post-taxonomy` に `getCategoriesWithCount()` を追加し、カテゴリ別記事数を集計できるようにした
- `posts-view` に `CategoryCount` 型と `categoryCounts` フィールドを追加
- `Sidebar` でカテゴリ名の右に `(N)` 形式で件数を表示するよう変更
- `BlogLayout` / `PostListPage` および全ページの props を `categories: string[]` → `categoryCounts: CategoryCount[]` に切り替え（既存の `categories` はロジック用途で継続利用）

## Test plan

- [ ] トップページ・記事詳細・カテゴリ・タグ各ページでサイドバーにカテゴリ件数が表示されること
- [ ] `bun run build` が正常に完了すること
- [ ] カテゴリリンクが正しく遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)