### PR TITLE
Align Learning Content Mobile TOC with Blog Style

### DIFF
--- a/src/components/LearningLayout.tsx
+++ b/src/components/LearningLayout.tsx
@@ -1,11 +1,11 @@
 // src/components/LearningLayout.tsx
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import type { TocItem } from '@/src/types/post';
 import type { LearningPostMeta, LearningCourseMeta } from '@/src/types/learning';
-import { BookOpen, List, ChevronRight, X } from 'lucide-react';
+import { BookOpen, List, ChevronRight, X, Menu } from 'lucide-react';
 
 interface LearningLayoutProps {
   children: React.ReactNode;
@@ -25,8 +25,29 @@ export default function LearningLayout({
   const [isChapterDrawerOpen, setIsChapterDrawerOpen] = useState(false);
   const [isTocDrawerOpen, setIsTocDrawerOpen] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const hasToc = !!(toc && toc.length > 0);
+
+  // モーダルオープン時のフォーカス移動とキーボード Esc キーでのクローズ
+  useEffect(() => {
+    if (!isTocDrawerOpen) return;
+
+    if (closeButtonRef.current) {
+      closeButtonRef.current.focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsTocDrawerOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isTocDrawerOpen]);
 
   // IntersectionObserverによるTOCのハイライト
   useEffect(() => {
@@ -133,15 +154,6 @@ export default function LearningLayout({
             <BookOpen className="h-4 w-4" />
             チャプター ({chapters.length})
           </button>
-          {hasToc && (
-            <button
-              onClick={() => setIsTocDrawerOpen(true)}
-              className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs font-extrabold theme-btn text-text"
-            >
-              <List className="h-4 w-4" />
-              ページ内目次
-            </button>
-          )}
         </div>
       </div>
 
@@ -205,31 +217,45 @@ export default function LearningLayout({
       )}
 
       {/* モバイル用：ページ内目次 (TOC) ドロワー */}
-      {isTocDrawerOpen && hasToc && (
-        <div
-          className="lg:hidden fixed inset-0 z-[100] flex justify-end"
-          role="dialog"
-          aria-modal="true"
-        >
+      {hasToc && (
+        <>
+          <button
+            onClick={() => setIsTocDrawerOpen(true)}
+            className="text-text lg:!hidden fixed bottom-18 right-6 z-40 w-12 h-12 theme-btn flex items-center justify-center"
+            aria-label="目次を開く"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+
           <div
-            className="bg-black/50 absolute inset-0 backdrop-blur-sm"
-            onClick={() => setIsTocDrawerOpen(false)}
-          />
-          <div className="relative bg-card w-80 max-w-[85vw] h-full p-6 border-l-3 border-border shadow-2xl flex flex-col">
-            <div className="flex items-center justify-between mb-6 pb-4 border-b-2 border-border">
-              <span className="font-extrabold text-text">ページ内目次</span>
-              <button
-                onClick={() => setIsTocDrawerOpen(false)}
-                className="p-1 hover:bg-secondary rounded-lg"
-              >
-                <X className="h-5 w-5 text-text/60" />
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto pr-1">
+            className={`lg:hidden fixed inset-0 z-[100] transition-opacity duration-300 ${isTocDrawerOpen ? 'opacity-100 visible' : 'opacity-0 invisible'}`}
+            role="dialog"
+            aria-modal="true"
+            aria-label="目次モーダル"
+            aria-hidden={!isTocDrawerOpen}
+          >
+            <div
+              className="bg-bg absolute inset-0 backdrop-blur-sm opacity-50"
+              onClick={() => setIsTocDrawerOpen(false)}
+            />
+            <div
+              className={`fixed bottom-0 left-0 right-0 bg-card rounded-t-3xl p-6 max-h-[80vh] overflow-y-auto border-t-3 border-border shadow-2xl transition-transform duration-300 ease-out theme-toc-drawer ${isTocDrawerOpen ? 'translate-y-0' : 'translate-y-full'}`}
+            >
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="font-extrabold text-lg text-text">目次</h2>
+                <button
+                  ref={closeButtonRef}
+                  onClick={() => setIsTocDrawerOpen(false)}
+                  className="p-2 text-text/50 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-lg"
+                  aria-label="目次を閉じる"
+                >
+                  ✕
+                </button>
+              </div>
               {renderTocList(() => setIsTocDrawerOpen(false))}
             </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/src/components/LearningLayout.tsx
+++ b/src/components/LearningLayout.tsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import type { TocItem } from '@/src/types/post';
 import type { LearningPostMeta, LearningCourseMeta } from '@/src/types/learning';
-import { BookOpen, List, ChevronRight, X, Menu } from 'lucide-react';
+import { BookOpen, ChevronRight, X, Menu } from 'lucide-react';
 
 interface LearningLayoutProps {
   children: React.ReactNode;


### PR DESCRIPTION
Replaces the top-bar mobile TOC button in `LearningLayout.tsx` with a bottom-right Floating Action Button that opens a bottom-sheet modal. This matches the established mobile TOC UI pattern used in the blog layout. Added Escape key handling and focus management for accessibility.

---
*PR created automatically by Jules for task [2561913456281845287](https://jules.google.com/task/2561913456281845287) started by @handism*