### PR TITLE
🧪 test: add tests for estimateReadingMinutes

### DIFF
--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,6 +1,6 @@
 // tests/utils.test.ts
 import { describe, expect, it } from 'vitest';
-import { categoryToSlug, tagToSlug } from '@/src/lib/utils';
+import { categoryToSlug, estimateReadingMinutes, tagToSlug } from '@/src/lib/utils';
 
 describe('tagToSlug', () => {
   it('英小文字はそのまま返す', () => {
@@ -59,5 +59,64 @@ describe('categoryToSlug', () => {
 
   it('tagToSlug と同じ変換ルールを持つ', () => {
     expect(categoryToSlug('IT Infrastructure')).toBe('it-infrastructure');
+  });
+});
+
+describe('estimateReadingMinutes', () => {
+  it('空文字の場合は1を返す', () => {
+    expect(estimateReadingMinutes('')).toBe(1);
+  });
+
+  it('短いCJK文字列の場合は1を返す', () => {
+    expect(estimateReadingMinutes('こんにちは世界')).toBe(1);
+  });
+
+  it('600文字のCJK文字列の場合は1を返す', () => {
+    expect(estimateReadingMinutes('あ'.repeat(600))).toBe(1);
+  });
+
+  it('601文字のCJK文字列の場合は2を返す', () => {
+    expect(estimateReadingMinutes('あ'.repeat(601))).toBe(2);
+  });
+
+  it('短い英語テキストの場合は1を返す', () => {
+    expect(estimateReadingMinutes('hello world')).toBe(1);
+  });
+
+  it('200語の英単語の場合は1を返す', () => {
+    const text = Array(200).fill('word').join(' ');
+    expect(estimateReadingMinutes(text)).toBe(1);
+  });
+
+  it('201語の英単語の場合は2を返す', () => {
+    const text = Array(201).fill('word').join(' ');
+    expect(estimateReadingMinutes(text)).toBe(2);
+  });
+
+  it('CJK文字列と英単語が混在している場合（合計1分未満）', () => {
+    // CJK: 300 / 600 = 0.5
+    // Eng: 100 / 200 = 0.5
+    // Total = 1
+    const text = 'あ'.repeat(300) + ' ' + Array(100).fill('word').join(' ');
+    expect(estimateReadingMinutes(text)).toBe(1);
+  });
+
+  it('CJK文字列と英単語が混在している場合（合計1分超過）', () => {
+    // CJK: 301 / 600 = 0.501...
+    // Eng: 100 / 200 = 0.5
+    // Total = 1.001... -> ceil -> 2
+    const text = 'あ'.repeat(301) + ' ' + Array(100).fill('word').join(' ');
+    expect(estimateReadingMinutes(text)).toBe(2);
+  });
+
+  it('数字や記号のみの場合は1を返す', () => {
+    expect(estimateReadingMinutes('1234567890 !@#$%^&*()_+')).toBe(1);
+  });
+
+  it('ハイフンやアポストロフィを含む英単語を正しくカウントする', () => {
+    // "it's" -> 1 word
+    // "well-known" -> 1 word
+    // total 2 words -> < 200 -> 1 minute
+    expect(estimateReadingMinutes("It's a well-known fact that")).toBe(1);
   });
 });


### PR DESCRIPTION
🎯 **What:** Added tests for the `estimateReadingMinutes` utility function in `src/lib/utils.ts` to address a testing gap.
📊 **Coverage:** The new tests cover:
- Empty strings
- Short and exact limit boundaries for CJK characters (600 characters)
- Short and exact limit boundaries for English words (200 words)
- Mixed CJK and English content, correctly calculating when combinations surpass a minute threshold
- Strings with only symbols or numbers
- English words with hyphens and apostrophes to match specific regex expectations
✨ **Result:** Enhanced test coverage for the reading time estimation feature, improving confidence for future refactoring. All tests pass successfully.

---
*PR created automatically by Jules for task [3099780143828837266](https://jules.google.com/task/3099780143828837266) started by @handism*