### PR TITLE
🧹 [Code Health] Replace 'any' with 'unknown' in catch clauses for json-to-ts tool

### DIFF
--- a/app/tools/json-to-ts/page.tsx
+++ b/app/tools/json-to-ts/page.tsx
@@ -23,8 +23,9 @@ export default function JsonToTsPage() {
       const parsed = JSON.parse(inputJson);
       const generated = generateTypes(parsed, rootName || 'Root', outputFormat);
       return { outputCode: generated, error: '' };
-    } catch (e: any) {
-      return { outputCode: '', error: `JSON解析エラー: ${e.message}` };
+    } catch (e: unknown) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      return { outputCode: '', error: `JSON解析エラー: ${errorMessage}` };
     }
   }, [inputJson, rootName, outputFormat]);
 
@@ -36,7 +37,7 @@ export default function JsonToTsPage() {
     try {
       const parsed = JSON.parse(inputJson);
       setInputJson(JSON.stringify(parsed, null, 2));
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(e);
     }
   };


### PR DESCRIPTION
🎯 **What:** The `any` type was replaced with `unknown` in `catch` blocks within `app/tools/json-to-ts/page.tsx`. Error messages are now safely extracted using an `instanceof Error` type guard.
💡 **Why:** This improves the maintainability and type safety of the codebase by enforcing type checking in the catch clause, avoiding the use of `any` which disables TypeScript's safety features.
✅ **Verification:** I ran `bun install` followed by `bun run lint`, `bun run type-check`, and `bun run test:unit`. All checks and tests passed cleanly. Code review also approved the change.
✨ **Result:** The component now uses strict types in error handling, making the logic safer without altering any underlying behavior.

---
*PR created automatically by Jules for task [6020267354999544663](https://jules.google.com/task/6020267354999544663) started by @handism*