### PR TITLE
🧹 fix: handle empty block in layout.tsx inline script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* フラッシュ防止スクリプト(デザインテーマ): キー名は THEME_STORAGE_KEY、フォールバック値は DEFAULT_THEME と一致させること */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('${THEME_STORAGE_KEY}')||'${DEFAULT_THEME}';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`,
+            __html: `(function(){try{var t=localStorage.getItem('${THEME_STORAGE_KEY}')||'${DEFAULT_THEME}';document.documentElement.setAttribute('data-theme',t);}catch(e){console.error('Failed to access localStorage:', e);}})();`,
           }}
         />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem={true}>


### PR DESCRIPTION
🎯 **What:** Handled an empty catch block in the `dangerouslySetInnerHTML` inline script within `app/layout.tsx`.
💡 **Why:** Accessing `localStorage` requires a try-catch block because environments with strict privacy settings or disabled third-party cookies throw exceptions (like `SecurityError`). Deleting the try-catch completely is unsafe, so instead I added a `console.error` to the catch block to log the error. This resolves the dead/empty code block warning while preventing uncaught exceptions that would crash the script.
✅ **Verification:** Verified the fix by running the unit tests (`bun run test:unit`) and the production build (`bun run build`). Code review confirmed the fix is correct and safe.
✨ **Result:** Improved code health and readability while preserving necessary robust error handling.

---
*PR created automatically by Jules for task [15969275782583285779](https://jules.google.com/task/15969275782583285779) started by @handism*