### PR TITLE
🧹 Extract keyboardRows static data from KeyboardEvents component

### DIFF
--- a/app/tools/keyboard-events/keyboard-data.ts
+++ b/app/tools/keyboard-events/keyboard-data.ts
@@ -1,0 +1,104 @@
+export interface KeyDef {
+  code: string;
+  label: string;
+  width?: string;
+}
+
+export type KeyboardRow = KeyDef[];
+
+export const keyboardRows: KeyboardRow[] = [
+  // Row 1
+  [
+    { code: 'Escape', label: 'Esc', width: 'w-10' },
+    { code: 'F1', label: 'F1' },
+    { code: 'F2', label: 'F2' },
+    { code: 'F3', label: 'F3' },
+    { code: 'F4', label: 'F4' },
+    { code: 'F5', label: 'F5' },
+    { code: 'F6', label: 'F6' },
+    { code: 'F7', label: 'F7' },
+    { code: 'F8', label: 'F8' },
+    { code: 'F9', label: 'F9' },
+    { code: 'F10', label: 'F10' },
+    { code: 'F11', label: 'F11' },
+    { code: 'F12', label: 'F12' },
+  ],
+  // Row 2
+  [
+    { code: 'Backquote', label: '` ~' },
+    { code: 'Digit1', label: '1 !' },
+    { code: 'Digit2', label: '2 @' },
+    { code: 'Digit3', label: '3 #' },
+    { code: 'Digit4', label: '4 $' },
+    { code: 'Digit5', label: '5 %' },
+    { code: 'Digit6', label: '6 ^' },
+    { code: 'Digit7', label: '7 &' },
+    { code: 'Digit8', label: '8 *' },
+    { code: 'Digit9', label: '9 (' },
+    { code: 'Digit0', label: '0 )' },
+    { code: 'Minus', label: '- _' },
+    { code: 'Equal', label: '= +' },
+    { code: 'Backspace', label: 'Delete ⌫', width: 'w-16 flex-grow' },
+  ],
+  // Row 3
+  [
+    { code: 'Tab', label: 'Tab ⇥', width: 'w-14' },
+    { code: 'KeyQ', label: 'Q' },
+    { code: 'KeyW', label: 'W' },
+    { code: 'KeyE', label: 'E' },
+    { code: 'KeyR', label: 'R' },
+    { code: 'KeyT', label: 'T' },
+    { code: 'KeyY', label: 'Y' },
+    { code: 'KeyU', label: 'U' },
+    { code: 'KeyI', label: 'I' },
+    { code: 'KeyO', label: 'O' },
+    { code: 'KeyP', label: 'P' },
+    { code: 'BracketLeft', label: '[ {' },
+    { code: 'BracketRight', label: '] }' },
+    { code: 'Backslash', label: '\\ |', width: 'w-12 flex-grow' },
+  ],
+  // Row 4
+  [
+    { code: 'CapsLock', label: 'Caps Lock', width: 'w-16' },
+    { code: 'KeyA', label: 'A' },
+    { code: 'KeyS', label: 'S' },
+    { code: 'KeyD', label: 'D' },
+    { code: 'KeyF', label: 'F' },
+    { code: 'KeyG', label: 'G' },
+    { code: 'KeyH', label: 'H' },
+    { code: 'KeyJ', label: 'J' },
+    { code: 'KeyK', label: 'K' },
+    { code: 'KeyL', label: 'L' },
+    { code: 'Semicolon', label: '; :' },
+    { code: 'Quote', label: '\' "' },
+    { code: 'Enter', label: 'Enter ↵', width: 'w-20 flex-grow' },
+  ],
+  // Row 5
+  [
+    { code: 'ShiftLeft', label: 'Shift ⇧', width: 'w-20' },
+    { code: 'KeyZ', label: 'Z' },
+    { code: 'KeyX', label: 'X' },
+    { code: 'KeyC', label: 'C' },
+    { code: 'KeyV', label: 'V' },
+    { code: 'KeyB', label: 'B' },
+    { code: 'KeyN', label: 'N' },
+    { code: 'KeyM', label: 'M' },
+    { code: 'Comma', label: ', <' },
+    { code: 'Period', label: '. >' },
+    { code: 'Slash', label: '/ ?' },
+    { code: 'ShiftRight', label: 'Shift ⇧', width: 'w-24 flex-grow' },
+  ],
+  // Row 6
+  [
+    { code: 'ControlLeft', label: 'Ctrl', width: 'w-12' },
+    { code: 'AltLeft', label: 'Opt ⌥', width: 'w-12' },
+    { code: 'MetaLeft', label: 'Cmd ⌘', width: 'w-14' },
+    { code: 'Space', label: 'Space', width: 'w-56 flex-grow' },
+    { code: 'MetaRight', label: 'Cmd ⌘', width: 'w-14' },
+    { code: 'AltRight', label: 'Opt ⌥', width: 'w-12' },
+    { code: 'ArrowLeft', label: '◀' },
+    { code: 'ArrowUp', label: '▲' },
+    { code: 'ArrowDown', label: '▼' },
+    { code: 'ArrowRight', label: '▶' },
+  ],
+];

--- a/app/tools/keyboard-events/page.tsx
+++ b/app/tools/keyboard-events/page.tsx
@@ -3,6 +3,7 @@
 import ToolPageLayout from '@/src/components/ToolPageLayout';
 import { useState, useEffect } from 'react';
 import { Keyboard, Trash2, ShieldAlert } from 'lucide-react';
+import { keyboardRows } from './keyboard-data';
 
 interface KeyHistoryItem {
   key: string;
@@ -92,104 +93,6 @@ export default function KeyboardEvents() {
     setCurrentEvent(null);
     setActiveCodes(new Set());
   };
-
-  // キーボードレイアウトの定義
-  const keyboardRows = [
-    // Row 1
-    [
-      { code: 'Escape', label: 'Esc', width: 'w-10' },
-      { code: 'F1', label: 'F1' },
-      { code: 'F2', label: 'F2' },
-      { code: 'F3', label: 'F3' },
-      { code: 'F4', label: 'F4' },
-      { code: 'F5', label: 'F5' },
-      { code: 'F6', label: 'F6' },
-      { code: 'F7', label: 'F7' },
-      { code: 'F8', label: 'F8' },
-      { code: 'F9', label: 'F9' },
-      { code: 'F10', label: 'F10' },
-      { code: 'F11', label: 'F11' },
-      { code: 'F12', label: 'F12' },
-    ],
-    // Row 2
-    [
-      { code: 'Backquote', label: '` ~' },
-      { code: 'Digit1', label: '1 !' },
-      { code: 'Digit2', label: '2 @' },
-      { code: 'Digit3', label: '3 #' },
-      { code: 'Digit4', label: '4 $' },
-      { code: 'Digit5', label: '5 %' },
-      { code: 'Digit6', label: '6 ^' },
-      { code: 'Digit7', label: '7 &' },
-      { code: 'Digit8', label: '8 *' },
-      { code: 'Digit9', label: '9 (' },
-      { code: 'Digit0', label: '0 )' },
-      { code: 'Minus', label: '- _' },
-      { code: 'Equal', label: '= +' },
-      { code: 'Backspace', label: 'Delete ⌫', width: 'w-16 flex-grow' },
-    ],
-    // Row 3
-    [
-      { code: 'Tab', label: 'Tab ⇥', width: 'w-14' },
-      { code: 'KeyQ', label: 'Q' },
-      { code: 'KeyW', label: 'W' },
-      { code: 'KeyE', label: 'E' },
-      { code: 'KeyR', label: 'R' },
-      { code: 'KeyT', label: 'T' },
-      { code: 'KeyY', label: 'Y' },
-      { code: 'KeyU', label: 'U' },
-      { code: 'KeyI', label: 'I' },
-      { code: 'KeyO', label: 'O' },
-      { code: 'KeyP', label: 'P' },
-      { code: 'BracketLeft', label: '[ {' },
-      { code: 'BracketRight', label: '] }' },
-      { code: 'Backslash', label: '\\ |', width: 'w-12 flex-grow' },
-    ],
-    // Row 4
-    [
-      { code: 'CapsLock', label: 'Caps Lock', width: 'w-16' },
-      { code: 'KeyA', label: 'A' },
-      { code: 'KeyS', label: 'S' },
-      { code: 'KeyD', label: 'D' },
-      { code: 'KeyF', label: 'F' },
-      { code: 'KeyG', label: 'G' },
-      { code: 'KeyH', label: 'H' },
-      { code: 'KeyJ', label: 'J' },
-      { code: 'KeyK', label: 'K' },
-      { code: 'KeyL', label: 'L' },
-      { code: 'Semicolon', label: '; :' },
-      { code: 'Quote', label: '\' "' },
-      { code: 'Enter', label: 'Enter ↵', width: 'w-20 flex-grow' },
-    ],
-    // Row 5
-    [
-      { code: 'ShiftLeft', label: 'Shift ⇧', width: 'w-20' },
-      { code: 'KeyZ', label: 'Z' },
-      { code: 'KeyX', label: 'X' },
-      { code: 'KeyC', label: 'C' },
-      { code: 'KeyV', label: 'V' },
-      { code: 'KeyB', label: 'B' },
-      { code: 'KeyN', label: 'N' },
-      { code: 'KeyM', label: 'M' },
-      { code: 'Comma', label: ', <' },
-      { code: 'Period', label: '. >' },
-      { code: 'Slash', label: '/ ?' },
-      { code: 'ShiftRight', label: 'Shift ⇧', width: 'w-24 flex-grow' },
-    ],
-    // Row 6
-    [
-      { code: 'ControlLeft', label: 'Ctrl', width: 'w-12' },
-      { code: 'AltLeft', label: 'Opt ⌥', width: 'w-12' },
-      { code: 'MetaLeft', label: 'Cmd ⌘', width: 'w-14' },
-      { code: 'Space', label: 'Space', width: 'w-56 flex-grow' },
-      { code: 'MetaRight', label: 'Cmd ⌘', width: 'w-14' },
-      { code: 'AltRight', label: 'Opt ⌥', width: 'w-12' },
-      { code: 'ArrowLeft', label: '◀' },
-      { code: 'ArrowUp', label: '▲' },
-      { code: 'ArrowDown', label: '▼' },
-      { code: 'ArrowRight', label: '▶' },
-    ],
-  ];
 
   return (
     <ToolPageLayout


### PR DESCRIPTION
🎯 **What:** Extracted `keyboardRows` static data and its associated types into a new file `app/tools/keyboard-events/keyboard-data.ts` and imported it back into `app/tools/keyboard-events/page.tsx`.

💡 **Why:** The `KeyboardEvents` component contained a large static array for keyboard layouts, increasing the component size unnecessarily. Extracting static configuration data improves readability and maintainability.

✅ **Verification:** Verified the correct implementation manually, checking types and imports. The change was validated by running unit testing, checking the build step and linting correctly.

✨ **Result:** Improved component code health and reduced file size.

---
*PR created automatically by Jules for task [1343055286568224222](https://jules.google.com/task/1343055286568224222) started by @handism*