### PR TITLE
🧪 [testing improvement] Add unit tests for generateTocFromHast

### DIFF
--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import { generateTocFromHast } from '../src/lib/toc';
+
+describe('generateTocFromHast', () => {
+  it('should generate TOC from valid h1-h6 tags', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h1',
+          properties: { id: 'heading-1' },
+          children: [{ type: 'text', value: 'Heading 1' }]
+        },
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'heading-2' },
+          children: [{ type: 'text', value: 'Heading 2' }]
+        },
+        {
+          type: 'element',
+          tagName: 'h6',
+          properties: { id: 'heading-6' },
+          children: [{ type: 'text', value: 'Heading 6' }]
+        }
+      ]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([
+      { id: 'heading-1', text: 'Heading 1', level: 1 },
+      { id: 'heading-2', text: 'Heading 2', level: 2 },
+      { id: 'heading-6', text: 'Heading 6', level: 6 }
+    ]);
+  });
+
+  it('should ignore non-heading tags', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: { id: 'paragraph' },
+          children: [{ type: 'text', value: 'Paragraph text' }]
+        },
+        {
+          type: 'element',
+          tagName: 'div',
+          children: [{ type: 'text', value: 'Div text' }]
+        }
+      ]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([]);
+  });
+
+  it('should handle nested elements and accumulate text', () => {
+    const tree = {
+      type: 'element',
+      tagName: 'h3',
+      properties: { id: 'nested-heading' },
+      children: [
+        { type: 'text', value: 'Heading ' },
+        {
+          type: 'element',
+          tagName: 'span',
+          children: [{ type: 'text', value: 'with span' }]
+        },
+        { type: 'text', value: ' and more' }
+      ]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([
+      { id: 'nested-heading', text: 'Heading with span and more', level: 3 }
+    ]);
+  });
+
+  it('should handle elements without ids', () => {
+    const tree = {
+      type: 'element',
+      tagName: 'h4',
+      children: [{ type: 'text', value: 'Heading without id' }]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([
+      { id: '', text: 'Heading without id', level: 4 }
+    ]);
+  });
+
+  it('should handle elements with non-string ids', () => {
+    const tree = {
+      type: 'element',
+      tagName: 'h5',
+      properties: { id: 123 },
+      children: [{ type: 'text', value: 'Heading with numeric id' }]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([
+      { id: '', text: 'Heading with numeric id', level: 5 }
+    ]);
+  });
+
+  it('should ignore headings with empty text', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'empty-1' },
+          children: [{ type: 'text', value: '   ' }] // Only spaces
+        },
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'empty-2' },
+          children: [] // No children
+        }
+      ]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([]);
+  });
+
+  it('should walk through nested structure to find headings', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'div',
+          children: [
+            {
+              type: 'element',
+              tagName: 'h2',
+              properties: { id: 'nested-h2' },
+              children: [{ type: 'text', value: 'Nested H2' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([
+      { id: 'nested-h2', text: 'Nested H2', level: 2 }
+    ]);
+  });
+
+  it('should return empty array for null or invalid inputs', () => {
+    expect(generateTocFromHast(null)).toEqual([]);
+    expect(generateTocFromHast(undefined)).toEqual([]);
+    expect(generateTocFromHast('string')).toEqual([]);
+    expect(generateTocFromHast(123)).toEqual([]);
+    expect(generateTocFromHast({})).toEqual([]); // Missing 'type' property
+  });
+
+  it('should return empty string for text nodes with null/undefined value', () => {
+      const tree = {
+        type: 'element',
+        tagName: 'h2',
+        properties: { id: 'heading-1' },
+        children: [{ type: 'text' }] // Missing value
+      };
+
+      const toc = generateTocFromHast(tree);
+      expect(toc).toEqual([]);
+  });
+});

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -10,28 +10,28 @@ describe('generateTocFromHast', () => {
           type: 'element',
           tagName: 'h1',
           properties: { id: 'heading-1' },
-          children: [{ type: 'text', value: 'Heading 1' }]
+          children: [{ type: 'text', value: 'Heading 1' }],
         },
         {
           type: 'element',
           tagName: 'h2',
           properties: { id: 'heading-2' },
-          children: [{ type: 'text', value: 'Heading 2' }]
+          children: [{ type: 'text', value: 'Heading 2' }],
         },
         {
           type: 'element',
           tagName: 'h6',
           properties: { id: 'heading-6' },
-          children: [{ type: 'text', value: 'Heading 6' }]
-        }
-      ]
+          children: [{ type: 'text', value: 'Heading 6' }],
+        },
+      ],
     };
 
     const toc = generateTocFromHast(tree);
     expect(toc).toEqual([
       { id: 'heading-1', text: 'Heading 1', level: 1 },
       { id: 'heading-2', text: 'Heading 2', level: 2 },
-      { id: 'heading-6', text: 'Heading 6', level: 6 }
+      { id: 'heading-6', text: 'Heading 6', level: 6 },
     ]);
   });
 
@@ -43,14 +43,14 @@ describe('generateTocFromHast', () => {
           type: 'element',
           tagName: 'p',
           properties: { id: 'paragraph' },
-          children: [{ type: 'text', value: 'Paragraph text' }]
+          children: [{ type: 'text', value: 'Paragraph text' }],
         },
         {
           type: 'element',
           tagName: 'div',
-          children: [{ type: 'text', value: 'Div text' }]
-        }
-      ]
+          children: [{ type: 'text', value: 'Div text' }],
+        },
+      ],
     };
 
     const toc = generateTocFromHast(tree);
@@ -67,29 +67,25 @@ describe('generateTocFromHast', () => {
         {
           type: 'element',
           tagName: 'span',
-          children: [{ type: 'text', value: 'with span' }]
+          children: [{ type: 'text', value: 'with span' }],
         },
-        { type: 'text', value: ' and more' }
-      ]
+        { type: 'text', value: ' and more' },
+      ],
     };
 
     const toc = generateTocFromHast(tree);
-    expect(toc).toEqual([
-      { id: 'nested-heading', text: 'Heading with span and more', level: 3 }
-    ]);
+    expect(toc).toEqual([{ id: 'nested-heading', text: 'Heading with span and more', level: 3 }]);
   });
 
   it('should handle elements without ids', () => {
     const tree = {
       type: 'element',
       tagName: 'h4',
-      children: [{ type: 'text', value: 'Heading without id' }]
+      children: [{ type: 'text', value: 'Heading without id' }],
     };
 
     const toc = generateTocFromHast(tree);
-    expect(toc).toEqual([
-      { id: '', text: 'Heading without id', level: 4 }
-    ]);
+    expect(toc).toEqual([{ id: '', text: 'Heading without id', level: 4 }]);
   });
 
   it('should handle elements with non-string ids', () => {
@@ -97,13 +93,11 @@ describe('generateTocFromHast', () => {
       type: 'element',
       tagName: 'h5',
       properties: { id: 123 },
-      children: [{ type: 'text', value: 'Heading with numeric id' }]
+      children: [{ type: 'text', value: 'Heading with numeric id' }],
     };
 
     const toc = generateTocFromHast(tree);
-    expect(toc).toEqual([
-      { id: '', text: 'Heading with numeric id', level: 5 }
-    ]);
+    expect(toc).toEqual([{ id: '', text: 'Heading with numeric id', level: 5 }]);
   });
 
   it('should ignore headings with empty text', () => {
@@ -114,15 +108,15 @@ describe('generateTocFromHast', () => {
           type: 'element',
           tagName: 'h2',
           properties: { id: 'empty-1' },
-          children: [{ type: 'text', value: '   ' }] // Only spaces
+          children: [{ type: 'text', value: '   ' }], // Only spaces
         },
         {
           type: 'element',
           tagName: 'h2',
           properties: { id: 'empty-2' },
-          children: [] // No children
-        }
-      ]
+          children: [], // No children
+        },
+      ],
     };
 
     const toc = generateTocFromHast(tree);
@@ -141,17 +135,15 @@ describe('generateTocFromHast', () => {
               type: 'element',
               tagName: 'h2',
               properties: { id: 'nested-h2' },
-              children: [{ type: 'text', value: 'Nested H2' }]
-            }
-          ]
-        }
-      ]
+              children: [{ type: 'text', value: 'Nested H2' }],
+            },
+          ],
+        },
+      ],
     };
 
     const toc = generateTocFromHast(tree);
-    expect(toc).toEqual([
-      { id: 'nested-h2', text: 'Nested H2', level: 2 }
-    ]);
+    expect(toc).toEqual([{ id: 'nested-h2', text: 'Nested H2', level: 2 }]);
   });
 
   it('should return empty array for null or invalid inputs', () => {
@@ -163,14 +155,14 @@ describe('generateTocFromHast', () => {
   });
 
   it('should return empty string for text nodes with null/undefined value', () => {
-      const tree = {
-        type: 'element',
-        tagName: 'h2',
-        properties: { id: 'heading-1' },
-        children: [{ type: 'text' }] // Missing value
-      };
+    const tree = {
+      type: 'element',
+      tagName: 'h2',
+      properties: { id: 'heading-1' },
+      children: [{ type: 'text' }], // Missing value
+    };
 
-      const toc = generateTocFromHast(tree);
-      expect(toc).toEqual([]);
+    const toc = generateTocFromHast(tree);
+    expect(toc).toEqual([]);
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The HAST parser logic in `generateTocFromHast` inside `src/lib/toc.ts` completely lacked unit test coverage. Because this function recursively extracts table-of-contents elements from abstract syntax trees, it needed tests that constructed valid and invalid HAST mock objects.

📊 **Coverage:** What scenarios are now tested
*   Valid heading parsing (h1-h6 tags mapping to correct levels).
*   Ignoring non-heading and irrelevant tags (p, div, etc.).
*   Handling deeply nested textual content inside a heading (e.g. spans inside headings).
*   Correct fallback logic when `id` attributes are missing or malformed (non-string ids).
*   Ignoring elements resulting in purely empty/whitespace text.
*   Invalid inputs like null, undefined, primitive data types, and incomplete AST objects without a `type`.

✨ **Result:** The improvement in test coverage
We now have reliable, deterministic test coverage for the TOC generation logic, catching edge cases in document generation ahead of time. Tests pass effortlessly with `bun run test:unit`.

---
*PR created automatically by Jules for task [11234258500032851052](https://jules.google.com/task/11234258500032851052) started by @handism*