### PR TITLE
🧪 test: add coverage for resolveSlugOrNotFound error path

### DIFF
--- a/tests/slug-resolver.test.ts
+++ b/tests/slug-resolver.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveSlugOrNotFound } from '../src/lib/slug-resolver';
+import { notFound } from 'next/navigation';
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}));
+
+describe('resolveSlugOrNotFound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const toSlug = (value: string) => value.toLowerCase();
+
+  it('returns the matched candidate when a match is found', () => {
+    const candidates = ['Apple', 'Banana', 'Cherry'];
+
+    const result = resolveSlugOrNotFound('banana', candidates, toSlug);
+
+    expect(result).toBe('Banana');
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('calls notFound when no match is found', () => {
+    const candidates = ['Apple', 'Banana', 'Cherry'];
+
+    const result = resolveSlugOrNotFound('orange', candidates, toSlug);
+
+    expect(notFound).toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
🎯 **What:** This PR adds test coverage for `resolveSlugOrNotFound` in `src/lib/slug-resolver.ts`, addressing a missing test for its error condition.

📊 **Coverage:**
- Tests the happy path where a matching slug is successfully found.
- Tests the error path where a matching slug is not found, asserting that Next.js's `notFound()` function is correctly invoked (via `vi.mock`).

✨ **Result:** Increased test coverage for navigation utility functions and improved reliability by ensuring correct behavior when slugs are invalid.

---
*PR created automatically by Jules for task [8494591040193045133](https://jules.google.com/task/8494591040193045133) started by @handism*