### PR TITLE
🧹 [Code Health] Remove any type from JSON to TS tool

### DIFF
--- a/app/tools/json-to-ts/page.tsx
+++ b/app/tools/json-to-ts/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 
 import ToolPageLayout from '@/src/components/ToolPageLayout';
@@ -45,7 +44,7 @@ export default function JsonToTsPage() {
   };
 
   function generateTypes(
-    value: any,
+    value: unknown,
     typeName: string,
     format: 'interface' | 'type' | 'zod'
   ): string {
@@ -56,7 +55,7 @@ export default function JsonToTsPage() {
       return str.charAt(0).toUpperCase() + str.slice(1);
     }
 
-    function resolveType(val: any, currentKey: string): string {
+    function resolveType(val: unknown, currentKey: string): string {
       if (val === null) return 'null';
       if (Array.isArray(val)) {
         if (val.length === 0) return 'any[]';
@@ -70,14 +69,14 @@ export default function JsonToTsPage() {
         const nestedName = capitalize(currentKey);
         if (!seenNames.has(nestedName)) {
           seenNames.add(nestedName);
-          buildType(val, nestedName);
+          buildType(val as Record<string, unknown>, nestedName);
         }
         return nestedName;
       }
       return typeof val;
     }
 
-    function resolveZod(val: any, currentKey: string, indent: string = '  '): string {
+    function resolveZod(val: unknown, currentKey: string, indent: string = '  '): string {
       if (val === null) return 'z.null()';
       if (Array.isArray(val)) {
         if (val.length === 0) return 'z.array(z.any())';
@@ -90,7 +89,7 @@ export default function JsonToTsPage() {
         return `z.array(z.union([${itemTypes.join(', ')}]))`;
       }
       if (typeof val === 'object') {
-        return buildZod(val, indent + '  ');
+        return buildZod(val as Record<string, unknown>, indent + '  ');
       }
       if (typeof val === 'string') return 'z.string()';
       if (typeof val === 'number') return 'z.number()';
@@ -98,7 +97,7 @@ export default function JsonToTsPage() {
       return 'z.any()';
     }
 
-    function buildType(obj: any, name: string) {
+    function buildType(obj: Record<string, unknown>, name: string) {
       const keys = Object.keys(obj);
       let output = '';
       if (format === 'interface') {
@@ -119,7 +118,7 @@ export default function JsonToTsPage() {
       generatedTypes.push(output);
     }
 
-    function buildZod(obj: any, indent: string): string {
+    function buildZod(obj: Record<string, unknown>, indent: string): string {
       const keys = Object.keys(obj);
       if (keys.length === 0) return 'z.object({})';
 
@@ -146,14 +145,14 @@ export default function JsonToTsPage() {
         }
         const sample = value[0];
         if (typeof sample === 'object' && sample !== null) {
-          buildType(sample, typeName + 'Item');
+          buildType(sample as Record<string, unknown>, typeName + 'Item');
           return generatedTypes.join('\n\n') + `\n\nexport type ${typeName} = ${typeName}Item[];`;
         } else {
           const typeStr = resolveType(sample, typeName);
           return `export type ${typeName} = ${typeStr}[];`;
         }
       }
-      buildType(value, typeName);
+      buildType(value as Record<string, unknown>, typeName);
       return generatedTypes.reverse().join('\n\n');
     }
   }


### PR DESCRIPTION
🎯 **What:** The `eslint-disable @typescript-eslint/no-explicit-any` comment was removed from `app/tools/json-to-ts/page.tsx`, and all instances of `any` in function signatures were replaced with `unknown` and `Record<string, unknown>`.
💡 **Why:** Using `any` defeats the purpose of TypeScript. Replacing it with `unknown` and proper type narrowing ensures type safety and improves maintainability without altering runtime behavior.
✅ **Verification:** Verified by running `bun run lint app/tools/json-to-ts/page.tsx`, `bun run type-check`, `bun run test:unit`, and `bun run test:vrt`. All checks and tests passed successfully.
✨ **Result:** The code is now more type-safe and no longer suppresses ESLint rules for explicit `any` usage.

---
*PR created automatically by Jules for task [1382537977664662696](https://jules.google.com/task/1382537977664662696) started by @handism*