### PR TITLE
🎨 Palette: Add aria-label to search input in ToolsDashboard

### DIFF
--- a/src/components/ToolsDashboard.tsx
+++ b/src/components/ToolsDashboard.tsx
@@ -87,6 +87,7 @@ export default function ToolsDashboard() {
           <input
             id="tool-search"
             type="text"
+            aria-label="ツール名や説明から検索"
             placeholder="ツール名や説明から検索..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 What: Added `aria-label="ツール名や説明から検索"` to the search input in `src/components/ToolsDashboard.tsx`.
🎯 Why: The search input was lacking an explicit accessible name (missing both an associated `<label for="tool-search">` and an `aria-label` attribute), which can degrade the experience for users relying on screen readers. This small change ensures screen readers properly announce the input's purpose.
♿ Accessibility: Improved screen reader compatibility by explicitly labeling the primary search input on the tools dashboard.

---
*PR created automatically by Jules for task [12953129357350007402](https://jules.google.com/task/12953129357350007402) started by @handism*