### PR TITLE
🎨 Palette: Add aria-labels and focus styles to clear history buttons

### DIFF
--- a/app/tools/keyboard-events/page.tsx
+++ b/app/tools/keyboard-events/page.tsx
@@ -282,8 +282,9 @@ export default function KeyboardEvents() {
                   {history.length > 0 && (
                     <button
                       onClick={clearHistory}
-                      className="p-1.5 hover:bg-red-500/10 hover:text-red-500 rounded-xl text-text/60 transition-colors cursor-pointer"
+                      className="p-1.5 hover:bg-red-500/10 hover:text-red-500 rounded-xl text-text/60 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-accent"
                       title="履歴をクリア"
+                      aria-label="履歴をクリア"
                     >
                       <Trash2 className="w-4 h-4" />
                     </button>

--- a/app/tools/keyboard-events/page.tsx
+++ b/app/tools/keyboard-events/page.tsx
@@ -282,7 +282,7 @@ export default function KeyboardEvents() {
                   {history.length > 0 && (
                     <button
                       onClick={clearHistory}
-                      className="p-1.5 hover:bg-red-500/10 hover:text-red-500 rounded-xl text-text/60 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-accent"
+                      className="p-1.5 hover:bg-red-500/10 hover:text-red-500 rounded-xl text-text/60 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                       title="履歴をクリア"
                       aria-label="履歴をクリア"
                     >

--- a/src/components/tools/calculator/StandardCalculator.tsx
+++ b/src/components/tools/calculator/StandardCalculator.tsx
@@ -577,7 +577,7 @@ export default function StandardCalculator() {
                     setHistory([]);
                     localStorage.removeItem('calc_history');
                   }}
-                  className="p-1 rounded-lg hover:bg-secondary text-text/40 hover:text-red-500 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-accent"
+                  className="p-1 rounded-lg hover:bg-secondary text-text/40 hover:text-red-500 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   title="履歴をクリア"
                   aria-label="履歴をクリア"
                 >

--- a/src/components/tools/calculator/StandardCalculator.tsx
+++ b/src/components/tools/calculator/StandardCalculator.tsx
@@ -577,8 +577,9 @@ export default function StandardCalculator() {
                     setHistory([]);
                     localStorage.removeItem('calc_history');
                   }}
-                  className="p-1 rounded-lg hover:bg-secondary text-text/40 hover:text-red-500 transition-colors cursor-pointer"
+                  className="p-1 rounded-lg hover:bg-secondary text-text/40 hover:text-red-500 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-accent"
                   title="履歴をクリア"
+                  aria-label="履歴をクリア"
                 >
                   <Trash2 className="w-4 h-4" />
                 </button>


### PR DESCRIPTION
💡 What: Added `aria-label="履歴をクリア"` and focus visible styles (`focus-visible:ring-2 focus-visible:ring-accent`) to icon-only "trash" buttons in the Keyboard Events Visualizer and Standard Calculator tools.

🎯 Why: To improve screen reader accessibility and keyboard navigation usability for these destructive action buttons, aligning with the `Palette` agent's UX coding standards.

♿ Accessibility:
- Improves screen reader context by providing a localized, descriptive label for icon-only buttons.
- Improves keyboard navigation by ensuring clear visual focus indicators.

---
*PR created automatically by Jules for task [17815758153112880509](https://jules.google.com/task/17815758153112880509) started by @handism*