### PR TITLE
🎨 Palette: Ensure accessible aria-label on icon-only `CopyButton` variants

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## 2026-07-11 - Add missing aria-label to dynamically created buttons
 **Learning:** Buttons created dynamically via DOM scripts (like `document.createElement('button')` in `CopyButtonScript.tsx`) can easily miss accessibility attributes that are typically standard on JSX components. Since the button text was "Copy" but the site is localized in Japanese, screen readers weren't getting an optimal experience.
 **Action:** Always verify that interactive elements created dynamically via DOM APIs have appropriate `aria-label` attributes set using `.setAttribute()`, and ensure the text aligns with the site's localization.
+## 2026-07-12 - [Accessible reusable UI components]
+**Learning:** Reusable UI components like `<CopyButton>` can be configured to show only icons by passing empty strings to `label` props. When this happens, screen readers lose the context. Providing a fallback `aria-label` attribute (e.g. `aria-label={title || label || 'コピー'}`) inside the reusable component prevents this accessibility issue across all usages.
+**Action:** When building generic reusable button components, always ensure that an `aria-label` is applied internally, falling back to a sensible default, to maintain accessibility even when consumers use the component in an icon-only configuration.

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -52,7 +52,7 @@ export default function CopyButton({
       onClick={() => copy(value)}
       disabled={disabled}
       title={title}
-      aria-label={title || label || 'コピー'}
+      aria-label={title || (copied ? copiedLabel || 'コピーしました' : label || 'コピー')}
       className={className}
     >
       {copied ? (

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -52,6 +52,7 @@ export default function CopyButton({
       onClick={() => copy(value)}
       disabled={disabled}
       title={title}
+      aria-label={title || label || 'コピー'}
       className={className}
     >
       {copied ? (


### PR DESCRIPTION
💡 **What**: Added a fallback `aria-label` to the `CopyButton` generic component.
🎯 **Why**: When the `CopyButton` component is used in an icon-only mode (by omitting the text label or explicitly passing `label=""`), it becomes inaccessible to screen readers because it lacks contextual text. Adding a fallback `aria-label` natively inside the component fixes this issue for all its usages across the application.
♿ **Accessibility**: Enhanced screen reader accessibility by ensuring the `CopyButton` always has an accessible name, falling back to either `title`, the original `label`, or the default string `'コピー'`. Also added a critical UX learning into `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [10031311253235453907](https://jules.google.com/task/10031311253235453907) started by @handism*