### PR TITLE
🎨 Palette: Add aria-label and focus-visible states to CopyButton

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2026-07-11 - Add missing aria-label to dynamically created buttons
 **Learning:** Buttons created dynamically via DOM scripts (like `document.createElement('button')` in `CopyButtonScript.tsx`) can easily miss accessibility attributes that are typically standard on JSX components. Since the button text was "Copy" but the site is localized in Japanese, screen readers weren't getting an optimal experience.
 **Action:** Always verify that interactive elements created dynamically via DOM APIs have appropriate `aria-label` attributes set using `.setAttribute()`, and ensure the text aligns with the site's localization.
+
+## 2026-07-12 - Reusable CopyButton Accessibility
+**Learning:** The reusable `CopyButton` component, when used as an icon-only button (e.g. `label=""`), loses its accessible name for screen readers. Providing a dynamic `aria-label` fallback that responds to the `copied` state ensures the component remains fully accessible regardless of how it's visually implemented.
+**Action:** When creating or updating reusable components that can conditionally hide their text labels, always implement an internal `aria-label` fallback to maintain context for screen readers.

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -24,7 +24,7 @@ type CopyButtonProps = {
 };
 
 const DEFAULT_CLASSNAME =
-  'theme-btn px-3 py-1.5 text-xs flex items-center gap-1.5 hover:text-accent transition-colors';
+  'theme-btn px-3 py-1.5 text-xs flex items-center gap-1.5 hover:text-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded';
 
 /**
  * コピー実行と「コピー完了」表示切り替えを内包した汎用コピーボタン。
@@ -53,6 +53,7 @@ export default function CopyButton({
       disabled={disabled}
       title={title}
       className={className}
+      aria-label={!label ? (copied ? copiedLabel || 'コピーしました' : 'コピー') : undefined}
     >
       {copied ? (
         <>


### PR DESCRIPTION
💡 What: Added a dynamic `aria-label` fallback to the `CopyButton` component that responds to the `copied` state when `label` is not provided. Also added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded` to the default styles.
🎯 Why: When `CopyButton` is used as an icon-only component (e.g. `label=""`), it loses its accessible name, meaning screen readers are not able to describe the button's purpose to users. The dynamic label fixes this while maintaining context (copying vs copied). The focus ring ensures keyboard accessibility context is maintained.
♿ Accessibility: Ensures the generic copy button maintains a valid accessible name and focus ring when text labels are omitted, improving screen reader and keyboard navigation UX.

---
*PR created automatically by Jules for task [4155753296787987656](https://jules.google.com/task/4155753296787987656) started by @handism*