### PR TITLE
🎨 Palette: Add dynamic fallback aria-label to CopyButton

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -46,12 +46,15 @@ export default function CopyButton({
 }: CopyButtonProps) {
   const { copied, copy } = useCopyToClipboard();
 
+  const currentAriaLabel = copied ? copiedLabel || 'コピーしました' : label || 'コピー';
+
   return (
     <button
       type="button"
       onClick={() => copy(value)}
       disabled={disabled}
       title={title}
+      aria-label={currentAriaLabel}
       className={className}
     >
       {copied ? (


### PR DESCRIPTION
💡 **What**: `CopyButton`コンポーネントがアイコンのみ（`label=""`など）で利用された場合でも、スクリーンリーダーから意味が伝わるようにフォールバックの`aria-label`を動的に設定する処理を追加しました。
🎯 **Why**: アイコンのみのボタンとして使われた際に、スクリーンリーダー等で「ボタン」としか読み上げられないアクセシビリティ上の課題を解決するためです。
♿ **Accessibility**: アイコンのみで表示される場合も、`label`や`copiedLabel`、もしくはデフォルトの「コピー」「コピーしました」というテキストを`aria-label`として持つようになり、キーボードナビゲーション時やスクリーンリーダー使用時の体験が向上します。

---
*PR created automatically by Jules for task [11992596831222114126](https://jules.google.com/task/11992596831222114126) started by @handism*