### PR TITLE
🎨 Palette: Improve CopyButton accessibility and focus states

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -21,6 +21,8 @@ type CopyButtonProps = {
   copiedLabelClassName?: string;
   disabled?: boolean;
   title?: string;
+  /** スクリーンリーダー用のラベル。指定しない場合は label またはフォールバック値が使われる */
+  ariaLabel?: string;
 };
 
 const DEFAULT_CLASSNAME =
@@ -43,8 +45,13 @@ export default function CopyButton({
   copiedLabelClassName,
   disabled = false,
   title,
+  ariaLabel,
 }: CopyButtonProps) {
   const { copied, copy } = useCopyToClipboard();
+
+  // aria-label を計算。ariaLabel prop があればそれを使用し、なければ label を使用。
+  // label が空文字（アイコンのみ）の場合はフォールバックとして "コピー" または "コピーしました" を使用する。
+  const computedAriaLabel = ariaLabel || (label ? label : copied ? 'コピーしました' : 'コピー');
 
   return (
     <button
@@ -52,7 +59,8 @@ export default function CopyButton({
       onClick={() => copy(value)}
       disabled={disabled}
       title={title}
-      className={className}
+      className={`${className} focus-visible:ring-2 focus-visible:ring-accent rounded`}
+      aria-label={computedAriaLabel}
     >
       {copied ? (
         <>


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label` and `focus-visible` styles to the shared `CopyButton` component.
🎯 **Why**: When `CopyButton` is rendered as an icon-only button (which happens frequently in code snippets and tool outputs), it lacked an accessible name for screen readers. Additionally, it lacked clear focus ring styles for keyboard users.
📸 **Before/After**: N/A (Visual change only applies to focus ring and screen reader semantics)
♿ **Accessibility**: Improved screen reader context by defaulting to "コピー" or "コピーしました", and improved keyboard navigation with explicit focus states.

---
*PR created automatically by Jules for task [16236748331907332185](https://jules.google.com/task/16236748331907332185) started by @handism*