### PR TITLE
🎨 Palette: Add internal fallback ARIA label to generic CopyButton

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## 2026-07-11 - Add missing aria-label to dynamically created buttons
 **Learning:** Buttons created dynamically via DOM scripts (like `document.createElement('button')` in `CopyButtonScript.tsx`) can easily miss accessibility attributes that are typically standard on JSX components. Since the button text was "Copy" but the site is localized in Japanese, screen readers weren't getting an optimal experience.
 **Action:** Always verify that interactive elements created dynamically via DOM APIs have appropriate `aria-label` attributes set using `.setAttribute()`, and ensure the text aligns with the site's localization.
+## 2024-05-18 - [Add fallback ARIA label to generic icon-only buttons]
+**Learning:** Generic reusable components that render buttons with an option to hide visible text (e.g., passing `label=""` to `<CopyButton>`) may easily lose their accessible name, causing screen readers to announce them incorrectly.
+**Action:** Always ensure an internal fallback `aria-label` is implemented in such generic components to maintain screen reader context, resolving it dynamically based on the current component state if needed.

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -49,7 +49,8 @@ export default function CopyButton({
 }: CopyButtonProps) {
   const { copied, copy } = useCopyToClipboard();
 
-  const resolvedAriaLabel = ariaLabel || (copied ? copiedLabel || 'コピーしました' : label || 'コピー');
+  const resolvedAriaLabel =
+    ariaLabel || (copied ? copiedLabel || 'コピーしました' : label || 'コピー');
 
   return (
     <button

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -11,6 +11,8 @@ type CopyButtonProps = {
   label?: string;
   /** コピー後のラベル */
   copiedLabel?: string;
+  /** スクリーンリーダー用のラベル。指定しない場合は label/copiedLabel またはフォールバック値が使われる */
+  ariaLabel?: string;
   className?: string;
   /** アイコンを表示するかどうか（テキストのみのボタン用） */
   showIcon?: boolean;
@@ -43,8 +45,11 @@ export default function CopyButton({
   copiedLabelClassName,
   disabled = false,
   title,
+  ariaLabel,
 }: CopyButtonProps) {
   const { copied, copy } = useCopyToClipboard();
+
+  const resolvedAriaLabel = ariaLabel || (copied ? copiedLabel || 'コピーしました' : label || 'コピー');
 
   return (
     <button
@@ -53,6 +58,7 @@ export default function CopyButton({
       disabled={disabled}
       title={title}
       className={className}
+      aria-label={resolvedAriaLabel}
     >
       {copied ? (
         <>


### PR DESCRIPTION
## 💡 What
Added an `ariaLabel` prop and an internal dynamic fallback mechanism to the `CopyButton` component to ensure it always has a valid `aria-label` attribute.

## 🎯 Why
When `CopyButton` is rendered in an icon-only mode (by passing `label=""`), it loses its accessible text, causing screen readers to improperly announce the control. Adding an explicit fallback prevents this accessibility regression across all usages of the component.

## ♿ Accessibility
* Added fallback `aria-label` resolution so the component announces "コピー" (Copy) or "コピーしました" (Copied) correctly depending on its internal state, even if visible labels are removed.

---
*PR created automatically by Jules for task [5065826909470256396](https://jules.google.com/task/5065826909470256396) started by @handism*